### PR TITLE
Fix typo

### DIFF
--- a/src/paket.fs
+++ b/src/paket.fs
@@ -240,7 +240,7 @@ let private createDependenciesProvider () =
                         match tags with
                         | [ _ ] ->
                             ["nuget"; "git"; "github"; "http"; "gist"; "versions"; "source"; "group"
-                             "references: strinct"; "framework:"; "content: none"; "copy_content_to_output_dir: always"
+                             "references: strict"; "framework:"; "content: none"; "copy_content_to_output_dir: always"
                              "import_targets:"; "copy_local:"; "redirects:"; "strategy:"; "lowest_matching:" ]
                             |> concatAndLift
                         | PaketTag "nuget" -> send word


### PR DESCRIPTION
"references: strinct" was clearly supposed to be "references: strict".