### PR TITLE
Show group in references completion

### DIFF
--- a/src/paket.fs
+++ b/src/paket.fs
@@ -297,16 +297,39 @@ let private createDependenciesProvider () =
                 } |> Case2
     }
 
+type InstalledPackage = {
+    group: string
+    name: string
+    version: string
+}
+
+let parsePaketList (lines: string[]) =
+    seq {
+        for line in lines do
+            let parts = line.Trim().Split(' ')
+            if parts.Length = 4 then
+                yield {
+                    group = parts.[0]
+                    name = parts.[1]
+                    version = parts.[3]
+                }
+    }
+
 let private createReferencesProvider () =
     {   new CompletionItemProvider
         with
             member this.provideCompletionItems(doc, pos, ct) =
-                "show-installed-packages -s"
-                |> execPaket
-                |> Promise.map (handlePaketList)
-                |> Promise.map (Seq.map(fun n -> n.Trim().Split(' ').[1] |> CompletionItem ))
-                |> Promise.map (ResizeArray)
-                |> Case2
+                promise {
+                    let! executionResult = "show-installed-packages -s" |> execPaket
+                    let installedPackages = handlePaketList executionResult |> parsePaketList
+                    return seq {
+                        for (name, inGroups) in Seq.groupBy (fun p -> p.name) installedPackages do
+                            let groups = String.Join(",", Seq.map (fun p -> p.group) inGroups)
+                            let item = CompletionItem name
+                            item.detail <- groups
+                            yield item
+                    } |> ResizeArray
+                } |> Case2
 
             member this.resolveCompletionItem(sug, ct) =
                 promise {


### PR DESCRIPTION
(Just playing a little with fable)

Show the group name in the completion list of paket.references files

![2017-06-29 23_22_47- extension development host - paket references fake visual studio code](https://user-images.githubusercontent.com/131878/27711435-876029f8-5d23-11e7-9013-fe91afe05146.png)
