### PR TITLE
Updated obsolete Paket API use

### DIFF
--- a/release/package.json
+++ b/release/package.json
@@ -75,7 +75,7 @@
 			"title": "Paket: Add NuGet Package"
 		},{
 			"command": "paket.Why",
-			"title": "Paket: Why is a packge included"
+			"title": "Paket: Why is a package included"
 		},{
 			"command": "paket.AddToCurrent",
 			"title": "Paket: Add NuGet Package (to current project)"

--- a/release/package.json
+++ b/release/package.json
@@ -96,8 +96,8 @@
 			"title": "Paket: Remove NuGet Package (from current project)"
 		},
 		{
-			"command": "paket.GenerateIncludeScripts",
-			"title": "Paket: Generate Include Scripts"
+			"command": "paket.GenerateLoadScripts",
+			"title": "Paket: Generate Load Scripts"
 		},
 		{
 			"command": "paket.UpdatePaketToPrerelease",
@@ -147,7 +147,7 @@
 		"onCommand:paket.RemovePackage",
 		"onCommand:paket.RemovePackageCurrent",
 		"onCommand:paket.UpdatePaketToPrerelease",
-		"onCommand:paket.GenerateIncludeScripts"
+		"onCommand:paket.GenerateLoadScripts"
 	],
 	"dependencies": {
 	}

--- a/src/paket.fs
+++ b/src/paket.fs
@@ -119,7 +119,7 @@ let private handlePaketList (error : ChildProcess.ExecError option, stdout : str
         |> Array.filter((<>) "" )
 
 let Init () = "init" |> spawnPaket
-let GenerateIncludeScripts () = "generate-include-scripts" |> spawnPaket
+let GenerateLoadScripts () = "generate-load-scripts" |> spawnPaket
 let Update () = "update" |> spawnPaket
 let Install () = "install" |> spawnPaket
 let Outdated () = "outdated" |> spawnPaket
@@ -429,6 +429,6 @@ let activate (context: vscode.ExtensionContext) =
     registerCommand "paket.UpdatePackageCurrent" UpdatePackageCurrent
     registerCommand "paket.RemovePackage" RemovePackage
     registerCommand "paket.RemovePackageCurrent" RemovePackageCurrent
-    registerCommand "paket.GenerateIncludeScripts" GenerateIncludeScripts
+    registerCommand "paket.GenerateLoadScripts" GenerateLoadScripts
 
     registerCommand "paket.UpdatePaketToPrerelease" UpdatePaketToAlpha


### PR DESCRIPTION
generate-include-scripts is obsolete, replaced by generate-load-scripts

https://fsprojects.github.io/Paket/paket-generate-include-scripts.html
https://fsprojects.github.io/Paket/paket-generate-load-scripts.html

Didn't try to build and test, sorry.