### PR TITLE
Add icons & menus to paket files

### DIFF
--- a/release/images/install-dark.svg
+++ b/release/images/install-dark.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g transform="matrix(1,0,0,1,-105,-89)">
+        <g transform="matrix(1.75,0,0,1.75,106.017,89.995)">
+            <path d="M4,0C1.79,0 0,1.79 0,4C0,6.21 1.79,8 4,8C6.21,8 8,6.21 8,4C8,1.79 6.21,0 4,0ZM3,1L5,1L5,4L7,4L4,7L1,4L3,4L3,1Z" style="fill:rgb(197,197,197);fill-rule:nonzero;"/>
+        </g>
+    </g>
+</svg>

--- a/release/images/install-light.svg
+++ b/release/images/install-light.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g transform="matrix(1,0,0,1,-105,-110)">
+        <g transform="matrix(1.75,0,0,1.75,106.017,110.995)">
+            <path d="M4,0C1.79,0 0,1.79 0,4C0,6.21 1.79,8 4,8C6.21,8 8,6.21 8,4C8,1.79 6.21,0 4,0ZM3,1L5,1L5,4L7,4L4,7L1,4L3,4L3,1Z" style="fill:rgb(101,101,101);fill-rule:nonzero;"/>
+        </g>
+    </g>
+</svg>

--- a/release/images/restore-dark.svg
+++ b/release/images/restore-dark.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g transform="matrix(1,0,0,1,-84,-89)">
+        <g transform="matrix(2,0,0,2,83.9795,90.995)">
+            <path d="M4,0C2.35,0 1,1.35 1,3L0,3L1.5,5L3,3L2,3C2,1.89 2.89,1 4,1L4,0ZM6.5,1L5,3L6,3C6,4.11 5.11,5 4,5L4,6C5.65,6 7,4.65 7,3L8,3L6.5,1Z" style="fill:rgb(197,197,197);fill-rule:nonzero;"/>
+        </g>
+    </g>
+</svg>

--- a/release/images/restore-light.svg
+++ b/release/images/restore-light.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:1.41421;">
+    <g transform="matrix(1,0,0,1,-84,-110)">
+        <g transform="matrix(2,0,0,2,83.9795,111.995)">
+            <path d="M4,0C2.35,0 1,1.35 1,3L0,3L1.5,5L3,3L2,3C2,1.89 2.89,1 4,1L4,0ZM6.5,1L5,3L6,3C6,4.11 5.11,5 4,5L4,6C5.65,6 7,4.65 7,3L8,3L6.5,1Z" style="fill:rgb(101,101,101);fill-rule:nonzero;"/>
+        </g>
+    </g>
+</svg>

--- a/release/package.json
+++ b/release/package.json
@@ -48,7 +48,12 @@
 			"title": "Paket: Init"
 		},{
 			"command": "paket.Install",
-			"title": "Paket: Install"
+			"title": "Paket: Install",
+			"icon":
+			{
+				"light": "./images/install-light.svg",
+				"dark": "./images/install-dark.svg"
+			}
 		},{
 			"command": "paket.Update",
 			"title": "Paket: Update"
@@ -57,7 +62,12 @@
 			"title": "Paket: Outdated"
 		},{
 			"command": "paket.Restore",
-			"title": "Paket: Restore"
+			"title": "Paket: Restore",
+			"icon":
+			{
+				"light": "./images/restore-light.svg",
+				"dark": "./images/restore-dark.svg"
+			}
 		},{
 			"command": "paket.AutoRestoreOn",
 			"title": "Paket: AutoRestore On"
@@ -103,6 +113,77 @@
 			"command": "paket.UpdatePaketToPrerelease",
 			"title": "Paket: Use Paket prerelease"
 		}],
+		"menus": {
+			"editor/title": [
+				{
+					"command":"paket.Restore",
+					"when": "editorLangId == 'paket-references'",
+					"group": "navigation"
+				},
+				{
+					"command":"paket.Restore",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "navigation"
+				},
+				{
+					"command":"paket.Install",
+					"when": "editorLangId == 'paket-references'",
+					"group": "navigation"
+				},
+				{
+					"command":"paket.Install",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "navigation"
+				}
+			],
+			"editor/context": [
+				{
+					"command":"paket.Restore",
+					"when": "editorLangId == 'paket-references'",
+					"group": "21_paketMain"
+				},
+				{
+					"command":"paket.Restore",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "21_paketMain"
+				},
+				{
+					"command":"paket.Install",
+					"when": "editorLangId == 'paket-references'",
+					"group": "21_paketMain"
+				},
+				{
+					"command":"paket.Install",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "21_paketMain"
+				},
+				{
+					"command":"paket.Add",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "22_paketEditFile"
+				},
+				{
+					"command":"paket.UpdatePackage",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "22_paketEditFile"
+				},
+				{
+					"command":"paket.RemovePackage",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "22_paketEditFile"
+				},
+				{
+					"command":"paket.Why",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "23_paketOther"
+				},
+				{
+					"command":"paket.GenerateLoadScripts",
+					"when": "editorLangId == 'paket-dependencies'",
+					"group": "23_paketOther"
+				}
+			]
+		},
 		"outputChannels": [
 			"Paket"
 		],


### PR DESCRIPTION
This PR add **Install** and **Restore** as icons on the top right (Of both dependencies and references files) and quite a few main actions in the context menu (of dependencies only)

![2018-01-22 01_21_03- extension development host - paket dependencies - iotestxxx - visual studio co](https://user-images.githubusercontent.com/131878/35200657-962d157c-ff12-11e7-9c5c-50af07af0dcf.png)

![2018-01-22 01_21_10- extension development host - paket dependencies - iotestxxx - visual studio co](https://user-images.githubusercontent.com/131878/35200676-bfef9cd6-ff12-11e7-9676-61a3c27f81e4.png)

Icons are modified versions of https://github.com/iconic/open-iconic ones (MIT) no idea where the copyright should be specified 😉 .