### PR TITLE
Globaltool

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -86,7 +86,7 @@ Target "DotNetRestore" <| fun () ->
     DotNetCli.Restore (fun p -> { p with WorkingDir = "src" } )
 
 let runFable additionalArgs =
-    let cmd = "fable webpack -- --config webpack.config.js " + additionalArgs
+    let cmd = "fable webpack --port free -- --config webpack.config.js " + additionalArgs
     DotNetCli.RunCommand (fun p -> { p with WorkingDir = "src" } ) cmd
 
 Target "Build" (fun _ ->


### PR DESCRIPTION
Here is a first implementation for #71 
Paket is detected from PATH env variable if not found with the existing logic
When used from env variable, we don't have to use mono and therefore I've added some exec / spawn functions without linuxcmd parameter.